### PR TITLE
Update API and major version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
       script:
         - npm run test
         - npm run test:mutate
+        - npm run codecov
     - stage: build
       script:
         - npm run prepublishOnly

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 1.0.0
+
+* Allow `SortingIcon` to take any amount of children
+* Remove dependency on react-render-as
+* Remove pseudo elements in favour of `tr`, `th`, and `td` props
+* Changed how components are exported
+* Changed coverage threshold to 100%
+* Changed mutation threshold to 100%
+
 ## 0.1.3
 
 * Don't use buggy React.Children.only

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![dependencies Status](https://david-dm.org/pikselpalette/react-sortable-column-table/status.svg)](https://david-dm.org/pikselpalette/react-sortable-column-table)
 [![devDependencies Status](https://david-dm.org/pikselpalette/react-sortable-column-table/dev-status.svg)](https://david-dm.org/pikselpalette/react-sortable-column-table?type=dev)
 [![peerDependencies Status](https://david-dm.org/pikselpalette/react-sortable-column-table/peer-status.svg)](https://david-dm.org/pikselpalette/react-sortable-column-table?type=peer)
+[![codecov](https://codecov.io/gh/pikselpalette/react-sortable-column-table/branch/master/graph/badge.svg)](https://codecov.io/gh/pikselpalette/react-sortable-column-table)
 
 A table with columns that can be reordered by dragging an icon in one of the cells
 

--- a/README.md
+++ b/README.md
@@ -21,24 +21,24 @@ npm i --save react-sortable-column-table
 ### Creating tables
 
 ```jsx
-import SortableTable from 'react-sortable-column-table';
+import SortableTable, { SortingIcon } from 'react-sortable-column-table';
 
 const table = (
   <SortableTable>
-    <SortableTable.Table>
-      <SortableTable.Header>
-        <SortableTable.Row>
-          <SortableTable.HeaderCell>Foo <SortableTable.SortingIcon /></SortableTable.HeaderCell>
-          <SortableTable.HeaderCell>Bar <SortableTable.SortingIcon /></SortableTable.HeaderCell>
-        </SortableTable.Row>
-      </SortableTable.Header>
-      <SortableTable.Body>
-        <SortableTable.Row>
-          <SortableTable.Cell>foo</SortableTable.Cell>
-          <SortableTable.Cell>bar</SortableTable.Cell>
-        </SortableTable.Row>
-      </SortableTable.Body>
-    </SortableTable.Table>
+    <table>
+      <thead>
+        <tr>
+          <th>Foo <SortingIcon /></th>
+          <th>Bar <SortingIcon /></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>foo</td>
+          <td>bar</td>
+        </tr>
+      </tbody>
+    </table>
   </SortableTable>
 );
 ```
@@ -46,31 +46,35 @@ const table = (
 ### Creating tables using semantic-ui
 
 ```jsx
-import SortableTable from 'react-sortable-table';
+import SortableTable, { SortingIcon } from 'react-sortable-column-table';
 import { Table } from 'semantic-ui-react';
 
 const semanticSortingIcon = (
-  <SortableTable.SortingIcon>
+  <SortingIcon>
     <Icon name="sort" rotated="clockwise" />
-  </SortableTable.SortingIcon>
+  </SortingIcon>
 );
 
 const table = (
-  <SortableTable>
-    <SortableTable.Table as={Table}>
-      <SortableTable.Header as={Table.Header}>
-        <SortableTable.Row as={Table.Row}>
-          <SortableTable.HeaderCell as={Table.HeaderCell}>Foo {semanticSortingIcon}</SortableTable.HeaderCell>
-          <SortableTable.HeaderCell as={Table.HeaderCell}>Bar {semanticSortingIcon}</SortableTable.HeaderCell>
-        </SortableTable.Row>
-      </SortableTable.Header>
-      <SortableTable.Body as={Table.Body}>
-        <SortableTable.Row as={Table.Row} key="1">
-          <SortableTable.Cell as={Table.Cell}>foo</SortableTable.Cell>
-          <SortableTable.Cell as={Table.Cell}>bar</SortableTable.Cell>
-        </SortableTable.Row>
-      </SortableTable.Body>
-    </SortableTable.Table>
+  <SortableTable
+    tr={Table.Row}
+    th={Table.HeaderCell}
+    td={Table.Cell}
+  >
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Foo {semanticSortingIcon}</Table.HeaderCell>
+          <Table.HeaderCell>Bar {semanticSortingIcon}</Table.HeaderCell>
+        </Table.Row>
+      </thead>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>foo</Table.Cell>
+          <Table.Cell>bar</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
   </SortableTable>
 );
 ```

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -21,6 +21,8 @@ type State = {
   }
 };
 
+export { SortingIcon };
+
 export default class SortableTable extends React.Component<Props, State> {
   ghostContainer: HTMLElement;
   element: HTMLElement;
@@ -34,7 +36,6 @@ export default class SortableTable extends React.Component<Props, State> {
   static Header = ProgressiveTable.Header;
   static Body = ProgressiveTable.Body;
   static Table = ProgressiveTable.Table;
-  static SortingIcon = SortingIcon;
 
   static waitMs: number = 40;
 
@@ -172,7 +173,7 @@ export default class SortableTable extends React.Component<Props, State> {
     index: number
   ): React.Element<SortableTable.Cell | SortableTable.HeaderCell> => {
     const children = React.Children.map(node.props.children, (child) => {
-      if (!child || child.type !== this.constructor.SortingIcon) return child;
+      if (!child || child.type !== SortingIcon) return child;
 
       if (!this.sortableColumns.includes(index)) {
         this.sortableColumns.push(index);

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -20,15 +20,16 @@ type State = {
   }
 };
 
-const SortingIcon = ({ children, ...rest }: { children?: React.ElementType }) => {
-  const child = React.Children.toArray(children)[0];
+const SortingIcon = ({ children, ...rest }: { children?: React.ElementType }) =>
+  React.Children.map(children, (child) => {
+    if (!child || !child.props) return child;
 
-  return React.cloneElement(
-    child,
-    { ...rest, ...child.props },
-    child.props.children
-  );
-};
+    return React.cloneElement(
+      child,
+      { ...rest, ...child.props },
+      child.props.children
+    );
+  });
 
 SortingIcon.defaultProps = {
   children: (

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import move from 'lodash-move';
+import ProgressiveTable from 'react-progressive-table';
 import SortingIcon from './sorting-icon';
 
 /** @memberOf SortableTable */
@@ -250,7 +251,12 @@ export default class SortableTable extends React.Component<Props, State> {
 
     return (
       <div ref={this.setElement} onDragEnd={this.handleDragEnd}>
-        {this.renderChildren(this.props.children)}
+        <ProgressiveTable
+          minimumRender={this.props.ghostRowsLimit}
+          tr={this.props.tr}
+        >
+          {this.renderChildren(this.props.children)}
+        </ProgressiveTable>
       </div>
     );
   }

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -9,7 +9,10 @@ type Props = {
   children: React.Node,
   onColumnOrder: Function,
   dragOpacity: number,
-  ghostRowsLimit: number
+  ghostRowsLimit: number,
+  tr: React.ElementType,
+  th: React.ElementType,
+  td: React.ElementType
 };
 
 /** @memberOf SortableTable */
@@ -29,18 +32,14 @@ export default class SortableTable extends React.Component<Props, State> {
   currentIndex: number;
   isDragging: boolean = false;
 
-  static Row = 'tr';
-  static Cell = 'td';
-  static HeaderCell = 'th';
-  static Header = 'thead';
-  static Body = 'tbody';
-  static Table = 'table';
-
   static waitMs: number = 40;
 
   static defaultProps = {
     dragOpacity: 0.1,
-    ghostRowsLimit: 16
+    ghostRowsLimit: 16,
+    tr: 'tr',
+    th: 'th',
+    td: 'td'
   };
 
   columnWidths: Array<number> = [];
@@ -56,7 +55,7 @@ export default class SortableTable extends React.Component<Props, State> {
   }
 
   getCellColumnProps(
-    node: React.Element<SortableTable.Cell | SortableTable.HeaderCell>,
+    node: React.ElementType,
     index: number
   ): Object {
     return {
@@ -167,10 +166,7 @@ export default class SortableTable extends React.Component<Props, State> {
     if (el) this.element = el;
   };
 
-  renderCell = (
-    node: React.Element<SortableTable.Cell | SortableTable.HeaderCell>,
-    index: number
-  ): React.Element<SortableTable.Cell | SortableTable.HeaderCell> => {
+  renderCell = (node: React.ElementType, index: number): React.ElementType => {
     const children = React.Children.map(node.props.children, (child) => {
       if (!child || child.type !== SortingIcon) return child;
 
@@ -203,7 +199,7 @@ export default class SortableTable extends React.Component<Props, State> {
   ): React.Node => React.Children.toArray(children).map((node) => {
     if (!node || !node.type) return node;
 
-    if ([this.constructor.HeaderCell, this.constructor.Cell].includes(node.type)) {
+    if ([this.props.th, this.props.td].includes(node.type)) {
       return this.renderCell(node, index);
     }
 
@@ -215,10 +211,10 @@ export default class SortableTable extends React.Component<Props, State> {
   });
 
   renderRow = (
-    row: React.Element<SortableTable.Row>,
+    row: React.ElementType,
     index: number,
     column: number
-  ): React.Element<SortableTable.Row> => {
+  ): React.ElementType => {
     const { children, ...props } = row.props;
 
     let reorderedChildren = React.Children.toArray(children);
@@ -240,7 +236,9 @@ export default class SortableTable extends React.Component<Props, State> {
 
   renderChildren(children: React.Node, column: number = -1): React.Node {
     return React.Children.toArray(children).map((node, index) => {
-      if (this.constructor.Row === node.type) {
+      if (!node || !node.props) return node;
+
+      if (this.props.tr === node.type) {
         return this.renderRow(node, index, column);
       }
 

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import move from 'lodash-move';
-import ProgressiveTable from 'react-progressive-table';
 import SortingIcon from './sorting-icon';
 
 /** @memberOf SortableTable */
@@ -30,12 +29,12 @@ export default class SortableTable extends React.Component<Props, State> {
   currentIndex: number;
   isDragging: boolean = false;
 
-  static Row = ProgressiveTable.Row;
-  static Cell = ProgressiveTable.Cell;
-  static HeaderCell = ProgressiveTable.HeaderCell;
-  static Header = ProgressiveTable.Header;
-  static Body = ProgressiveTable.Body;
-  static Table = ProgressiveTable.Table;
+  static Row = 'tr';
+  static Cell = 'td';
+  static HeaderCell = 'th';
+  static Header = 'thead';
+  static Body = 'tbody';
+  static Table = 'table';
 
   static waitMs: number = 40;
 
@@ -219,7 +218,7 @@ export default class SortableTable extends React.Component<Props, State> {
     row: React.Element<SortableTable.Row>,
     index: number,
     column: number
-  ): React.Element<ProgressiveTable.Row> => {
+  ): React.Element<SortableTable.Row> => {
     const { children, ...props } = row.props;
 
     let reorderedChildren = React.Children.toArray(children);
@@ -258,9 +257,7 @@ export default class SortableTable extends React.Component<Props, State> {
 
     return (
       <div ref={this.setElement} onDragEnd={this.handleDragEnd}>
-        <ProgressiveTable minimumRender={this.props.ghostRowsLimit}>
-          {this.renderChildren(this.props.children)}
-        </ProgressiveTable>
+        {this.renderChildren(this.props.children)}
       </div>
     );
   }

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -54,10 +54,7 @@ export default class SortableTable extends React.Component<Props, State> {
     return this.sortableColumns.includes(index);
   }
 
-  getCellColumnProps(
-    node: React.ElementType,
-    index: number
-  ): Object {
+  getCellColumnProps(node: React.Element<any>, index: number): Object {
     return {
       ...node.props,
       key: node.key,
@@ -166,7 +163,7 @@ export default class SortableTable extends React.Component<Props, State> {
     if (el) this.element = el;
   };
 
-  renderCell = (node: React.ElementType, index: number): React.ElementType => {
+  renderCell = (node: React.Element<any>, index: number): React.Node => {
     const children = React.Children.map(node.props.children, (child) => {
       if (!child || child.type !== SortingIcon) return child;
 
@@ -194,7 +191,7 @@ export default class SortableTable extends React.Component<Props, State> {
   };
 
   renderRowChildren = (
-    children: React.Node,
+    children: React.ChildrenArray<React.Element<any>>,
     index: number
   ): React.Node => React.Children.toArray(children).map((node) => {
     if (!node || !node.type) return node;
@@ -211,10 +208,10 @@ export default class SortableTable extends React.Component<Props, State> {
   });
 
   renderRow = (
-    row: React.ElementType,
+    row: React.Element<any>,
     index: number,
     column: number
-  ): React.ElementType => {
+  ): React.Node => {
     const { children, ...props } = row.props;
 
     let reorderedChildren = React.Children.toArray(children);

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import move from 'lodash-move';
 import ProgressiveTable from 'react-progressive-table';
+import SortingIcon from './sorting-icon';
 
 /** @memberOf SortableTable */
 type Props = {
@@ -18,25 +19,6 @@ type State = {
     oldIndex: number,
     newIndex: number
   }
-};
-
-const SortingIcon = ({ children, ...rest }: { children?: React.ElementType }) =>
-  React.Children.map(children, (child) => {
-    if (!child || !child.props) return child;
-
-    return React.cloneElement(
-      child,
-      { ...rest, ...child.props },
-      child.props.children
-    );
-  });
-
-SortingIcon.defaultProps = {
-  children: (
-    <span>
-      {'<>'}
-    </span>
-  )
 };
 
 export default class SortableTable extends React.Component<Props, State> {

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -145,9 +145,7 @@ export default class SortableTable extends React.Component<Props, State> {
     const ghost = document.createElement('div');
     this.ghostContainer.append(ghost);
 
-    if (document.body) {
-      document.body.append(this.ghostContainer);
-    }
+    ((document.body: any): HTMLBodyElement).append(this.ghostContainer);
 
     ReactDOM.render(
       (
@@ -160,7 +158,7 @@ export default class SortableTable extends React.Component<Props, State> {
   }
 
   setElement = (el: HTMLElement | null) => {
-    if (el) this.element = el;
+    this.element = ((el: any): HTMLElement);
   };
 
   renderCell = (node: React.Element<any>, index: number): React.Node => {

--- a/lib/sorting-icon.js
+++ b/lib/sorting-icon.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from 'react';
+
+const SortingIcon = ({ children, ...rest }: { children?: React.ElementType }) =>
+  React.Children.map(children, (child) => {
+    if (!child || !child.props) return child;
+
+    return React.cloneElement(
+      child,
+      { ...rest, ...child.props },
+      child.props.children
+    );
+  });
+
+SortingIcon.defaultProps = {
+  children: (
+    <span>
+      {'<>'}
+    </span>
+  )
+};
+
+export default SortingIcon;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-column-table",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9489,6 +9489,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.0.tgz",
       "integrity": "sha512-8ADZg/mBw+t2Fbr5Hm1K64v8q8Q6E+DprV5wQ5A8PSLW6XP0XJFMdUskVEW8efQ5oUgWHn8EYdHEPAMF0Co6hA==",
       "dev": true
+    },
+    "react-progressive-table": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-progressive-table/-/react-progressive-table-1.0.0.tgz",
+      "integrity": "sha512-XAi2m2ZCoO7KD8TA9ssmygCbRU1vjG7hRGKDrDagNZDUjZ2RlnO7rCgXCo+z2GLXqbzLPrVHJ8HOlUlPlBehvQ=="
     },
     "react-reconciler": {
       "version": "0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -640,6 +640,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2584,6 +2590,18 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "codecov": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.4.tgz",
+      "integrity": "sha512-KJyzHdg9B8U9LxXa7hS6jnEW5b1cNckLYc2YpnJ1nEFiOW+/iSzDHp+5MYEIQd9fN3/tC6WmGZmYiwxzkuGp/A==",
+      "dev": true,
+      "requires": {
+        "argv": "^0.0.2",
+        "ignore-walk": "^3.0.1",
+        "request": "^2.87.0",
+        "urlgrey": "^0.4.4"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -5466,6 +5484,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
       "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
       "dev": true
+    },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -11458,6 +11485,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
+    },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
     },
     "use": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-column-table",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9490,14 +9490,6 @@
       "integrity": "sha512-8ADZg/mBw+t2Fbr5Hm1K64v8q8Q6E+DprV5wQ5A8PSLW6XP0XJFMdUskVEW8efQ5oUgWHn8EYdHEPAMF0Co6hA==",
       "dev": true
     },
-    "react-progressive-table": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/react-progressive-table/-/react-progressive-table-0.1.2.tgz",
-      "integrity": "sha512-IIsaOM7logskkgFkkAZ0mkHPOBWmAmDDXttEIkhm15YGlXWfVZvQWYxjqsl9SZVICf69UN07p8UX+cjVGcMVwA==",
-      "requires": {
-        "react-render-as": "^0.1.0"
-      }
-    },
     "react-reconciler": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.7.0.tgz",
@@ -9509,11 +9501,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
       }
-    },
-    "react-render-as": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/react-render-as/-/react-render-as-0.1.1.tgz",
-      "integrity": "sha512-6qdUvQLiRd6GTcaWbZ/DLc6kn1xKDZNi/3WEPa3fdAnjn2RkKFkqgYNKwBXClcAFwFaT8RWBSv1Mzv9EKYcclA=="
     },
     "react-test-renderer": {
       "version": "16.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 100,
-        "branches": 91,
+        "branches": 100,
         "lines": 100,
         "functions": 100
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "flow": "./node_modules/.bin/flow",
     "test": "NODE_ENV=test jest --coverage",
     "test:watch": "NODE_ENV=test jest --watch",
-    "test:mutate": "NODE_ENV=test stryker run"
+    "test:mutate": "NODE_ENV=test stryker run",
+    "codecov": "codecov"
   },
   "jest": {
     "testMatch": [
@@ -61,6 +62,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
+    "codecov": "^3.0.4",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "webpack-cli": "^2.1.3"
   },
   "dependencies": {
-    "lodash-move": "^1.1.1"
+    "lodash-move": "^1.1.1",
+    "react-progressive-table": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "webpack-cli": "^2.1.3"
   },
   "dependencies": {
-    "lodash-move": "^1.1.1",
-    "react-progressive-table": "^0.1.2"
+    "lodash-move": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-sortable-column-table",
   "description": "A table with columns that can be reordered by dragging an icon in one of the cells",
-  "version": "0.1.3",
+  "version": "1.0.0",
   "author": "Sam Boylett <sam.boylett@piksel.com>",
   "main": "dist/index.js",
   "scripts": {

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -22,8 +22,8 @@ module.exports = (config) => {
     maxConcurrentTestRunners: 6,
     thresholds: {
       high: 100,
-      low: 96,
-      break: 96
+      low: 100,
+      break: 100
     }
   });
 };

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -69,6 +69,29 @@ describe('SortableTable', () => {
     document.body.innerHTML = '';
   });
 
+  it('works fine with a null child', () => {
+    expect(() => {
+      mount((
+        <SortableTable>
+          {null}
+          <i>Icon</i>
+        </SortableTable>
+      ));
+    }).not.toThrow();
+  });
+
+  it('works fine with a untyped row child', () => {
+    expect(() => {
+      mount((
+        <SortableTable>
+          <tr>
+            Test
+          </tr>
+        </SortableTable>
+      ));
+    }).not.toThrow();
+  });
+
   describe('instance', () => {
     beforeEach(setupComponent);
 

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -3,14 +3,14 @@ import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import 'jest-enzyme';
-import SortableTable from '../../lib/sortable-table';
+import SortableTable, { SortingIcon } from '../../lib/sortable-table';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('SortableTable', () => {
   const TestComponent = ({ children }) => (<b>{children}</b>);
   const PassThroughComponent = ({ children }) => children;
-  const sortingIcon = () => (<SortableTable.SortingIcon />);
+  const sortingIcon = () => (<SortingIcon />);
 
   let component;
   let instance;
@@ -163,7 +163,7 @@ describe('SortableTable', () => {
               const icon = header()
                 .find('th')
                 .at(1)
-                .find(SortableTable.SortingIcon);
+                .find(SortingIcon);
 
               icon.simulate('dragstart', getDragEvent());
 
@@ -175,7 +175,7 @@ describe('SortableTable', () => {
             const icon = header()
               .find('th')
               .at(0)
-              .find(SortableTable.SortingIcon);
+              .find(SortingIcon);
 
             icon.simulate('dragstart', getDragEvent());
 
@@ -197,7 +197,7 @@ describe('SortableTable', () => {
 
               jest.useFakeTimers();
               dragEvent = getDragEvent();
-              dragColumnCell = header().find('th').find(SortableTable.SortingIcon).at(2);
+              dragColumnCell = header().find('th').find(SortingIcon).at(2);
               dragColumnCell.simulate('dragstart', dragEvent);
             });
 
@@ -388,7 +388,7 @@ describe('SortableTable', () => {
 
               describe('when dropping on an element within', () => {
                 beforeEach(() => {
-                  columnCell.find(SortableTable.SortingIcon).simulate('drop');
+                  columnCell.find(SortingIcon).simulate('drop');
                 });
 
                 it('calls the onColumnOrder callback', () => {
@@ -571,7 +571,7 @@ describe('SortableTable', () => {
         expect(headers).toHaveLength(4);
 
         for (let i = 0; i < headers.length; i++) {
-          const icon = headers.at(i).find(SortableTable.SortingIcon);
+          const icon = headers.at(i).find(SortingIcon);
 
           if (i === 3) {
             expect(icon).toHaveLength(0);
@@ -582,7 +582,7 @@ describe('SortableTable', () => {
       });
 
       it('renders SortingIcon with the correct props', () => {
-        const icon = component.find(SortableTable.SortingIcon).first();
+        const icon = component.find(SortingIcon).first();
 
         expect(icon).toHaveProp('draggable', true);
         expect(icon).toHaveProp('style', { cursor: 'grab' });

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -17,32 +17,32 @@ describe('SortableTable', () => {
   let mockProps;
 
   const getChildren = () => (
-    <SortableTable.Table>
-      <SortableTable.Header>
-        <SortableTable.Row>
-          <SortableTable.HeaderCell>Dave {sortingIcon()}</SortableTable.HeaderCell>
+    <table>
+      <thead>
+        <tr>
+          <th>Dave {sortingIcon()}</th>
           <PassThroughComponent>
-            <SortableTable.HeaderCell>Jamie {sortingIcon()}</SortableTable.HeaderCell>
+            <th>Jamie {sortingIcon()}</th>
           </PassThroughComponent>
-          <SortableTable.HeaderCell>Joe {sortingIcon()}</SortableTable.HeaderCell>
-          <SortableTable.HeaderCell>No sorting</SortableTable.HeaderCell>
-        </SortableTable.Row>
-      </SortableTable.Header>
-      <SortableTable.Body>
-        <SortableTable.Row>
-          <SortableTable.Cell style={{ fontWeight: 'bold' }}>foo</SortableTable.Cell>
-          <SortableTable.Cell>bar</SortableTable.Cell>
-          <SortableTable.Cell><TestComponent>Bam</TestComponent></SortableTable.Cell>
-          <SortableTable.Cell>Action</SortableTable.Cell>
-        </SortableTable.Row>
-        <SortableTable.Row>
-          <SortableTable.Cell>whizz {sortingIcon()}</SortableTable.Cell>
-          <SortableTable.Cell>woop {sortingIcon()}</SortableTable.Cell>
-          <SortableTable.Cell>binary star system {sortingIcon()}</SortableTable.Cell>
-          <SortableTable.Cell>Action</SortableTable.Cell>
-        </SortableTable.Row>
-      </SortableTable.Body>
-    </SortableTable.Table>
+          <th>Joe {sortingIcon()}</th>
+          <th>No sorting</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td style={{ fontWeight: 'bold' }}>foo</td>
+          <td>bar</td>
+          <td><TestComponent>Bam</TestComponent></td>
+          <td>Action</td>
+        </tr>
+        <tr>
+          <td>whizz {sortingIcon()}</td>
+          <td>woop {sortingIcon()}</td>
+          <td>binary star system {sortingIcon()}</td>
+          <td>Action</td>
+        </tr>
+      </tbody>
+    </table>
   );
 
   const getRequiredProps = () => ({
@@ -121,16 +121,16 @@ describe('SortableTable', () => {
         beforeEach(() => {
           component.setProps({
             children: (
-              <SortableTable.Table>
-                <SortableTable.Header>
-                  <SortableTable.Row>
-                    <SortableTable.HeaderCell>Dave</SortableTable.HeaderCell>
-                    <SortableTable.HeaderCell>Jamie {sortingIcon()}</SortableTable.HeaderCell>
-                    <SortableTable.HeaderCell>Joe {sortingIcon()}</SortableTable.HeaderCell>
-                    <SortableTable.HeaderCell>No sorting {sortingIcon()}</SortableTable.HeaderCell>
-                  </SortableTable.Row>
-                </SortableTable.Header>
-              </SortableTable.Table>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Dave</th>
+                    <th>Jamie {sortingIcon()}</th>
+                    <th>Joe {sortingIcon()}</th>
+                    <th>No sorting {sortingIcon()}</th>
+                  </tr>
+                </thead>
+              </table>
             )
           });
 
@@ -566,7 +566,7 @@ describe('SortableTable', () => {
       });
 
       it('renders a column ordering icon where SortingIcon is used', () => {
-        const headers = header().find(SortableTable.HeaderCell);
+        const headers = header().find('th');
 
         expect(headers).toHaveLength(4);
 

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -70,33 +70,6 @@ describe('SortableTable', () => {
     document.body.innerHTML = '';
   });
 
-  describe('SortingIcon', () => {
-    it('renders a span with <> as default', () => {
-      expect(mount((
-        <SortableTable.SortingIcon />
-      )).find('span')).toHaveText('<>');
-    });
-
-    it('renders children if passed children', () => {
-      expect(mount((
-        <SortableTable.SortingIcon>
-          <b>Icon</b>
-        </SortableTable.SortingIcon>
-      )).find('b')).toHaveText('Icon');
-    });
-
-    it('works fine with 2 children', () => {
-      expect(() => {
-        mount((
-          <SortableTable.SortingIcon>
-            <b>Icon</b>
-            <i>Icon</i>
-          </SortableTable.SortingIcon>
-        ));
-      }).not.toThrow();
-    });
-  });
-
   describe('instance', () => {
     beforeEach(setupComponent);
 

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -69,7 +69,7 @@ describe('SortableTable', () => {
     document.body.innerHTML = '';
   });
 
-  it('works fine with a null child', () => {
+  it('renders correctly with a null child', () => {
     expect(() => {
       mount((
         <SortableTable>
@@ -80,7 +80,7 @@ describe('SortableTable', () => {
     }).not.toThrow();
   });
 
-  it('works fine with a untyped row child', () => {
+  it('renders correctly with an untyped row child', () => {
     expect(() => {
       mount((
         <SortableTable>

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -85,7 +85,7 @@ describe('SortableTable', () => {
       )).find('b')).toHaveText('Icon');
     });
 
-    it('errors if passing 2 children', () => {
+    it('works fine with 2 children', () => {
       expect(() => {
         mount((
           <SortableTable.SortingIcon>
@@ -93,7 +93,7 @@ describe('SortableTable', () => {
             <i>Icon</i>
           </SortableTable.SortingIcon>
         ));
-      }).toThrow();
+      }).not.toThrow();
     });
   });
 

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -10,7 +10,6 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('SortableTable', () => {
   const TestComponent = ({ children }) => (<b>{children}</b>);
   const PassThroughComponent = ({ children }) => children;
-  const sortingIcon = () => (<SortingIcon />);
 
   let component;
   let instance;
@@ -20,11 +19,11 @@ describe('SortableTable', () => {
     <table>
       <thead>
         <tr>
-          <th>Dave {sortingIcon()}</th>
+          <th>Dave <SortingIcon /></th>
           <PassThroughComponent>
-            <th>Jamie {sortingIcon()}</th>
+            <th>Jamie <SortingIcon /></th>
           </PassThroughComponent>
-          <th>Joe {sortingIcon()}</th>
+          <th>Joe <SortingIcon /></th>
           <th>No sorting</th>
         </tr>
       </thead>
@@ -36,9 +35,9 @@ describe('SortableTable', () => {
           <td>Action</td>
         </tr>
         <tr>
-          <td>whizz {sortingIcon()}</td>
-          <td>woop {sortingIcon()}</td>
-          <td>binary star system {sortingIcon()}</td>
+          <td>whizz <SortingIcon /></td>
+          <td>woop <SortingIcon /></td>
+          <td>binary star system <SortingIcon /></td>
           <td>Action</td>
         </tr>
       </tbody>
@@ -125,9 +124,9 @@ describe('SortableTable', () => {
                 <thead>
                   <tr>
                     <th>Dave</th>
-                    <th>Jamie {sortingIcon()}</th>
-                    <th>Joe {sortingIcon()}</th>
-                    <th>No sorting {sortingIcon()}</th>
+                    <th>Jamie <SortingIcon /></th>
+                    <th>Joe <SortingIcon /></th>
+                    <th>No sorting <SortingIcon /></th>
                   </tr>
                 </thead>
               </table>

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -406,6 +406,17 @@ describe('SortableTable', () => {
                 it('sets isDragging to false', () => {
                   expect(instance.isDragging).toBe(false);
                 });
+
+                describe('when dragging ends', () => {
+                  beforeEach(() => {
+                    jest.spyOn(instance, 'setState');
+                    table().simulate('dragend');
+                  });
+
+                  it('does not call setState again', () => {
+                    expect(instance.setState).not.toHaveBeenCalled();
+                  });
+                });
               });
 
               describe('when dropping on an element within', () => {

--- a/test/spec/sorting-icon.js
+++ b/test/spec/sorting-icon.js
@@ -1,0 +1,35 @@
+/* globals jest */
+import React from 'react';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import 'jest-enzyme';
+import SortingIcon from '../../lib/sorting-icon';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('SortingIcon', () => {
+  it('renders a span with <> as default', () => {
+    expect(mount((
+      <SortingIcon />
+    )).find('span')).toHaveText('<>');
+  });
+
+  it('renders children if passed children', () => {
+    expect(mount((
+      <SortingIcon>
+        <b>Icon</b>
+      </SortingIcon>
+    )).find('b')).toHaveText('Icon');
+  });
+
+  it('works fine with 2 children', () => {
+    expect(() => {
+      mount((
+        <SortingIcon>
+          <b>Icon</b>
+          <i>Icon</i>
+        </SortingIcon>
+      ));
+    }).not.toThrow();
+  });
+});

--- a/test/spec/sorting-icon.js
+++ b/test/spec/sorting-icon.js
@@ -32,4 +32,15 @@ describe('SortingIcon', () => {
       ));
     }).not.toThrow();
   });
+
+  it('works fine with a null child', () => {
+    expect(() => {
+      mount((
+        <SortingIcon>
+          {null}
+          <i>Icon</i>
+        </SortingIcon>
+      ));
+    }).not.toThrow();
+  });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = {
     filename: 'index.js',
     libraryTarget: 'umd'
   },
+  externals: ['react', 'react-dom'],
   module: {
     rules: [
       {


### PR DESCRIPTION
This removes the need to use `react-render-as` in favour of using `tr`, `td`, and `th` props to set the cell and row component types. It also changes the way `SortingIcon` is exported, and allows it to have any number of children.

Mutation and test coverage have been upped to 100%