### PR TITLE
Stop children keys changing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+* Use React.Children.map in most places to prevent pointless remounting of child components
+
 ## 1.0.0
 
 * Allow `SortingIcon` to take any amount of children

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -213,20 +213,24 @@ export default class SortableTable extends React.Component<Props, State> {
   ): React.Node => {
     const { children, ...props } = row.props;
 
-    let reorderedChildren = React.Children.toArray(children);
+    let reorderedChildren = children;
 
     if (this.state.reorder) {
       const { oldIndex, newIndex } = this.state.reorder;
 
-      reorderedChildren = move(reorderedChildren, oldIndex, newIndex);
+      reorderedChildren = move(
+        React.Children.toArray(reorderedChildren),
+        oldIndex,
+        newIndex
+      );
     }
 
     return React.cloneElement(
       row,
       props,
       column === -1
-        ? reorderedChildren.map(this.renderRowChildren)
-        : this.renderRowChildren(reorderedChildren[column], 0)
+        ? React.Children.map(reorderedChildren, this.renderRowChildren)
+        : this.renderRowChildren(React.Children.toArray(reorderedChildren)[column], 0)
     );
   };
 

--- a/lib/sortable-table.js
+++ b/lib/sortable-table.js
@@ -192,7 +192,7 @@ export default class SortableTable extends React.Component<Props, State> {
   renderRowChildren = (
     children: React.ChildrenArray<React.Element<any>>,
     index: number
-  ): React.Node => React.Children.toArray(children).map((node) => {
+  ): React.Node => React.Children.map(children, (node) => {
     if (!node || !node.type) return node;
 
     if ([this.props.th, this.props.td].includes(node.type)) {
@@ -231,7 +231,7 @@ export default class SortableTable extends React.Component<Props, State> {
   };
 
   renderChildren(children: React.Node, column: number = -1): React.Node {
-    return React.Children.toArray(children).map((node, index) => {
+    return React.Children.map(children, (node, index) => {
       if (!node || !node.props) return node;
 
       if (this.props.tr === node.type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-sortable-column-table",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-sortable-column-table",
   "description": "A table with columns that can be reordered by dragging an icon in one of the cells",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Sam Boylett <sam.boylett@piksel.com>",
   "main": "dist/index.js",
   "scripts": {

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -113,6 +113,35 @@ describe('SortableTable', () => {
     it('has not updated', () => {
       expect(updateCount).toEqual(0);
     });
+
+    describe('when component re-renders', () => {
+      beforeEach(() => {
+        component.setProps({
+          children: (
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    <TestComponentRemount />
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+            </table>
+          )
+        });
+        component.update();
+      });
+
+      it('has not remounted', () => {
+        expect(mountCount).toEqual(1);
+      });
+
+      it('has updated', () => {
+        expect(updateCount).toEqual(1);
+      });
+    });
   });
 
   it('renders correctly with a null child', () => {

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -74,15 +74,15 @@ describe('SortableTable', () => {
     let updateCount;
 
     class TestComponentRemount extends React.Component {
-      componentDidMount() {
+      componentDidMount() { // eslint-disable-line class-methods-use-this
         mountCount++;
       }
 
-      componentDidUpdate() {
+      componentDidUpdate() { // eslint-disable-line class-methods-use-this
         updateCount++;
       }
 
-      render() {
+      render() { // eslint-disable-line class-methods-use-this
         return null;
       }
     }

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -69,6 +69,52 @@ describe('SortableTable', () => {
     document.body.innerHTML = '';
   });
 
+  describe('when it has a child which should not remount', () => {
+    let mountCount;
+    let updateCount;
+
+    class TestComponentRemount extends React.Component {
+      componentDidMount() {
+        mountCount++;
+      }
+
+      componentDidUpdate() {
+        updateCount++;
+      }
+
+      render() {
+        return null;
+      }
+    }
+
+    beforeEach(() => {
+      mountCount = 0;
+      updateCount = 0;
+
+      setupComponent({
+        children: (
+          <table>
+            <thead>
+              <tr>
+                <th>
+                  <TestComponentRemount />
+                </th>
+              </tr>
+            </thead>
+          </table>
+        )
+      });
+    });
+
+    it('mounts a single time', () => {
+      expect(mountCount).toEqual(1);
+    });
+
+    it('has not updated', () => {
+      expect(updateCount).toEqual(0);
+    });
+  });
+
   it('renders correctly with a null child', () => {
     expect(() => {
       mount((

--- a/test/spec/sortable-table.js
+++ b/test/spec/sortable-table.js
@@ -141,6 +141,38 @@ describe('SortableTable', () => {
       it('has updated', () => {
         expect(updateCount).toEqual(1);
       });
+
+      describe('when component re-renders again', () => {
+        beforeEach(() => {
+          component.setProps({
+            children: (
+              <table>
+                <thead>
+                  <tr>
+                    <th>
+                      <TestComponentRemount />
+                    </th>
+                    <th>
+                      Test
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                </tbody>
+              </table>
+            )
+          });
+          component.update();
+        });
+
+        it('has not remounted', () => {
+          expect(mountCount).toEqual(1);
+        });
+
+        it('has updated', () => {
+          expect(updateCount).toEqual(2);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This stops children keys changing, forcing them to render as new components rather than updating the old components.